### PR TITLE
[FIX] public_budget_tax_settlement: fix ensure_one error when paying settlement with multiple settled lines

### DIFF
--- a/public_budget_tax_settlement/models/account_move.py
+++ b/public_budget_tax_settlement/models/account_move.py
@@ -10,7 +10,8 @@ class AccoutMove(models.Model):
     )
 
     def action_pay_tax_settlement(self):
-        return self.settled_line_ids.action_pay_tax_settlement()
+        line = self.settled_line_ids.filtered(lambda l: l.tax_state == 'to_pay')[:1]
+        return line.action_pay_tax_settlement()
 
     def _compute_matched_to_pay(self):
         for rec in self:


### PR DESCRIPTION
## Summary

- `action_pay_tax_settlement` en `account.move` llamaba `self.settled_line_ids.action_pay_tax_settlement()` sobre múltiples registros
- `account.move.line.action_pay_tax_settlement()` tiene `self.ensure_one()` al inicio → `ValueError: too many values to unpack`
- Fix: filtrar al primer registro con `tax_state == 'to_pay'` antes de llamar el método (todas las líneas apuntan al mismo asiento de liquidación, por lo que el resultado es idéntico)

## Test plan

- [ ] Crear una liquidación de impuestos con más de una línea liquidada
- [ ] Verificar que el botón "Pay" abre el formulario de pago sin error

🤖 Generated with [Claude Code](https://claude.com/claude-code)